### PR TITLE
Fix the JNLP using http instead of https when the jnlp URL is on http…

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosComputer/mesos-slave-agent.jnlp.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosComputer/mesos-slave-agent.jnlp.jelly
@@ -45,7 +45,22 @@
         </j:if>
 
         <argument>-url</argument>
-        <argument>${app.rootUrlFromRequest}</argument>
+        <argument>${rootURL}</argument>
+
+        <j:if test="${rootURL!=app.rootUrlFromRequest}">
+          <!--
+            rootURL is based on the URL in the system config, but there has been
+            numerous reports about people moving Jenkins to another place but
+            forgetting to update it. To improve the user experience in this regard,
+            let's also pass the URL that the browser sent us as well, so that the
+            JNLP Main class can try both.
+
+            Note that rootURL is still necessary in various situations, such
+            as reverse HTTP proxy situation, which makes rootUrlFromRequest incorrect.
+          -->
+          <argument>-url</argument>
+          <argument>${app.rootUrlFromRequest}</argument>
+        </j:if>
       </application-desc>
     </jnlp>
 </j:jelly>


### PR DESCRIPTION
There is a bug where if a site uses https only and forwards http to https, then when jnlp is starting it will use "http" and since it gets a 301, it throws an exception.

INFO: Locating server among [http://example.com/]
Jun 18, 2015 8:11:45 PM hudson.remoting.jnlp.Main$CuiListener error
SEVERE: http://example.com/tcpSlaveAgentListener/ is invalid: 301 MOVED PERMANENTLY
java.lang.Exception: http://example.com/tcpSlaveAgentListener/ is invalid: 301 MOVED PERMANENTLY
  at hudson.remoting.Engine.run(Engine.java:214)